### PR TITLE
case-insensitive bump

### DIFF
--- a/ascii.cabal
+++ b/ascii.cabal
@@ -16,5 +16,5 @@ Library
                      , bytestring       >= 0.9           && < 0.10
                      , text             >= 0.11          && < 0.12
                      , blaze-builder    >= 0.2.1.4       && < 0.4
-                     , case-insensitive >= 0.2           && < 0.4
+                     , case-insensitive >= 0.2           && < 0.5
   Ghc-options:         -Wall


### PR DESCRIPTION
case-insensitive 0.4 works well with ascii as the only change to its API is the removal of FoldCase instance of Char.
