### PR TITLE
ascii.cabal should have Homepage, Bug-Reports, and Source-Repository fields.

### DIFF
--- a/ascii.cabal
+++ b/ascii.cabal
@@ -1,14 +1,21 @@
 Name:                ascii
 Version:             0.0.2.2
 Synopsis:            Type-safe, bytestring-based ASCII values.
+Description:         Type-safe, bytestring-based ASCII values.
 License:             BSD3
 License-file:        LICENSE
 Author:              Michael Snoyman
 Maintainer:          michael@snoyman.com
 Stability:           Stable
 Category:            Data
+Homepage:            https://github.com/snoyberg/ascii
+Bug-Reports:         https://github.com/snoyberg/ascii/issues
 Build-type:          Simple
-Cabal-version:       >=1.2
+Cabal-version:       >= 1.6
+
+Source-Repository head
+    Type:     git
+    Location: git://github.com/snoyberg/ascii.git
 
 Library
   Exposed-modules:     Data.Ascii


### PR DESCRIPTION
Without those fields it's hard to find where the repository is.
