### PR TITLE
Ascii should be an instance of Hashable

### DIFF
--- a/Data/Ascii.hs
+++ b/Data/Ascii.hs
@@ -64,6 +64,7 @@ import qualified Data.ByteString.Char8 as S8
 import qualified Data.Char as C
 import Data.String (IsString (..))
 import Data.Data (Data)
+import Data.Hashable (Hashable)
 import Data.Typeable (Typeable)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -73,7 +74,7 @@ import Data.Monoid (Monoid)
 import Data.CaseInsensitive (FoldCase, CI, mk, original)
 
 newtype Ascii = Ascii ByteString
-    deriving (Show, Eq, Read, Ord, Data, Typeable, IsString, FoldCase, Monoid)
+    deriving (Show, Eq, Read, Ord, Data, Typeable, IsString, FoldCase, Hashable, Monoid)
 
 type CIAscii = CI Ascii
 

--- a/ascii.cabal
+++ b/ascii.cabal
@@ -17,4 +17,5 @@ Library
                      , text             >= 0.11          && < 0.12
                      , blaze-builder    >= 0.2.1.4       && < 0.4
                      , case-insensitive >= 0.2           && < 0.4
+                     , hashable         >= 1.0           && < 1.2
   Ghc-options:         -Wall


### PR DESCRIPTION
Since case-insensitive already depends on hashable, this would be harmless.
